### PR TITLE
ci: use macos-latest in nuget workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - os: ubuntu-latest
             rid: linux-x64
-          - os: macos-13
+          - os: macos-latest
             rid: osx-x64
           - os: windows-latest
             rid: win-x64


### PR DESCRIPTION
macos-13 jobs are being auto-cancelled; align nuget.yml with ci.yml/release.yml by using macos-latest for osx-x64 build.