### PR TITLE
Fix NuGet Windows DLL staging

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -103,7 +103,7 @@ jobs:
           if (!(Test-Path .\out\decentdb.dll)) { throw "Native DLL not found" }
 
       - name: Upload native artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: native-${{ matrix.rid }}
           path: out/
@@ -123,7 +123,7 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           path: native
 

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -98,6 +98,7 @@ jobs:
           New-Item -ItemType Directory -Force out | Out-Null
           if (Test-Path .\decentdb.dll) { Copy-Item -Force .\decentdb.dll out\decentdb.dll }
           if (Test-Path .\build\decentdb.dll) { Copy-Item -Force .\build\decentdb.dll out\decentdb.dll }
+          if (Test-Path .\build\c_api.dll) { Copy-Item -Force .\build\c_api.dll out\decentdb.dll }
           if (Test-Path .\build\libc_api.dll) { Copy-Item -Force .\build\libc_api.dll out\decentdb.dll }
           if (!(Test-Path .\out\decentdb.dll)) { throw "Native DLL not found" }
 


### PR DESCRIPTION
Windows   Verifying dependencies for decentdb@1.0.0
     Info:  Dependency on cligen@>= 1.7.0 already satisfied
  Verifying dependencies for cligen@1.9.6
     Info:  Dependency on zip@>= 0.3.1 already satisfied
  Verifying dependencies for zip@0.3.1
  Executing task build_lib in /home/steven/source/decentdb/decentdb.nimble outputs , but nuget.yml only looked for /, causing the win-x64 matrix job to fail during staging. This adds a check to copy  into  so the native-win-x64 artifact is produced.