### PR TITLE
Retry artifact uploads

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -103,10 +103,14 @@ jobs:
           if (!(Test-Path .\out\decentdb.dll)) { throw "Native DLL not found" }
 
       - name: Upload native artifact
-        uses: actions/upload-artifact@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          name: native-${{ matrix.rid }}
-          path: out/
+          attempt_limit: 3
+          attempt_delay: 10000
+          action: actions/upload-artifact@v4
+          with: |
+            name: native-${{ matrix.rid }}
+            path: out/
 
   pack-and-push:
     name: Pack + push NuGet
@@ -123,7 +127,7 @@ jobs:
           dotnet-version: "10.0.x"
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: native
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,12 +106,16 @@ jobs:
           Compress-Archive -Path dist\* -DestinationPath $out -Force
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: Wandalen/wretry.action@v3.8.0
         with:
-          name: release-${{ matrix.os }}
-          path: |
-            decentdb-${{ github.ref_name }}-${{ runner.os }}-x64.tar.gz
-            decentdb-${{ github.ref_name }}-${{ runner.os }}-x64.zip
+          attempt_limit: 3
+          attempt_delay: 10000
+          action: actions/upload-artifact@v4
+          with: |
+            name: release-${{ matrix.os }}
+            path: |
+              decentdb-${{ github.ref_name }}-${{ runner.os }}-x64.tar.gz
+              decentdb-${{ github.ref_name }}-${{ runner.os }}-x64.zip
 
   release:
     name: Create GitHub Release
@@ -120,7 +124,7 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 


### PR DESCRIPTION
GitHub blocked artifact actions v3 (deprecation), so we must stay on v4.

This wraps the `actions/upload-artifact@v4` steps in both `nuget.yml` and `release.yml` with `Wandalen/wretry.action` to retry transient FinalizeArtifact 403/network failures (3 attempts, 10s delay). It also restores `actions/download-artifact@v4`.
