### PR TITLE
Update NuGet workflow to publish to both GitHub Packages and NuGet.or…

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -2,16 +2,14 @@ name: Publish NuGet (DecentDB.MicroOrm)
 
 on:
   push:
-    tags:
-      - "v0.1.*"
-      - "v1.0.0"
-      - "v1.0.0-rc.*"
-      - "v1.0.1"
-      - "v1.0.1-rc.*"
+    tags: [
+      "v*"
+    ]
   workflow_dispatch:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   build-native:
@@ -150,7 +148,11 @@ jobs:
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
 
-          if [[ "$tag" =~ ^v1\.0\.1$ ]]; then
+          if [[ "$tag" =~ ^v1\.0\.2$ ]]; then
+            nuget="1.0.2"
+          elif [[ "$tag" =~ ^v1\.0\.2-rc\.([0-9]+)$ ]]; then
+            nuget="1.0.2-rc.${BASH_REMATCH[1]}"
+          elif [[ "$tag" =~ ^v1\.0\.1$ ]]; then
             nuget="1.0.1"
           elif [[ "$tag" =~ ^v1\.0\.1-rc\.([0-9]+)$ ]]; then
             nuget="1.0.1-rc.${BASH_REMATCH[1]}"
@@ -180,14 +182,29 @@ jobs:
             -o ./artifacts \
             bindings/dotnet/src/DecentDB.MicroOrm/DecentDB.MicroOrm.csproj
 
-      - name: Push
+      - name: Publish to GitHub Packages
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet nuget push ./artifacts/*.nupkg \
+            --api-key "${{ secrets.GITHUB_TOKEN }}" \
+            --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" \
+            --skip-duplicate
+
+      - name: Publish to NuGet.org
+        continue-on-error: true
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         shell: bash
         run: |
           set -euo pipefail
-          test -n "$NUGET_API_KEY"
-          dotnet nuget push ./artifacts/*.nupkg \
-            --api-key "$NUGET_API_KEY" \
-            --source https://api.nuget.org/v3/index.json \
-            --skip-duplicate
+          if [ -n "$NUGET_API_KEY" ]; then
+            dotnet nuget push ./artifacts/*.nupkg \
+              --api-key "$NUGET_API_KEY" \
+              --source https://api.nuget.org/v3/index.json \
+              --skip-duplicate
+          else
+            echo "NUGET_API_KEY not set, skipping NuGet.org publish"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to DecentDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.1] - Unreleased
+## [1.0.2] - Unreleased
+
+### Changed
+- NuGet package now publishes to both GitHub Packages and NuGet.org
+
+## [1.0.1] - 2026-02-11
 
 ### Fixed
 - .NET: NuGet package packing now places managed assemblies under `lib/net10.0/` so nuget.org correctly reports supported frameworks.

--- a/bindings/dotnet/src/DecentDB.MicroOrm/DecentDB.MicroOrm.csproj
+++ b/bindings/dotnet/src/DecentDB.MicroOrm/DecentDB.MicroOrm.csproj
@@ -5,11 +5,12 @@
     <Nullable>enable</Nullable>
 
     <PackageId>DecentDB.MicroOrm</PackageId>
-    <Description>DecentDB Micro-ORM (.NET 10) with bundled native engine</Description>
+    <Description>Lightweight Micro-ORM for DecentDB with bundled native runtime</Description>
     <Authors>DecentDB contributors</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>icon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/sphildreth/decentdb</PackageProjectUrl>
     <RepositoryUrl>https://github.com/sphildreth/decentdb</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
 

--- a/decentdb.nimble
+++ b/decentdb.nimble
@@ -1,4 +1,4 @@
-version       = "1.0.1"
+version       = "1.0.2"
 author        = "DecentDB contributors"
 description   = "DecentDB engine"
 license       = "Apache-2.0"

--- a/docs/development/releases.md
+++ b/docs/development/releases.md
@@ -41,19 +41,28 @@ Examples:
 ### GitHub release binaries
 
 - Workflow: `.github/workflows/release.yml`
-- Trigger: tags `v0.1.*`, `v1.0.0-rc.*`, `v1.0.0`, `v1.0.1-rc.*`, `v1.0.1`
+- Trigger: tags `v*`
 - Output: release artifacts containing the DecentDB CLI and the native library for Linux/Windows/macOS.
 
 ### NuGet publishing
 
 - Workflow: `.github/workflows/nuget.yml`
-- Trigger: tags `v0.1.*`, `v1.0.0-rc.*`, `v1.0.0`, `v1.0.1-rc.*`, `v1.0.1`
+- Trigger: tags `v*`
 - Package: `DecentDB.MicroOrm`
 - Target framework: `.NET 10` only (`net10.0`)
+- Publishing targets:
+  - **GitHub Packages**: Automatically published using `GITHUB_TOKEN` (no configuration needed)
+  - **NuGet.org**: Published if `NUGET_API_KEY` secret is configured
 
-Required secret:
+Required secrets:
 
-- `NUGET_API_KEY` (repo Actions secret)
+- `NUGET_API_KEY` (optional) - API key for publishing to NuGet.org
+  - Obtain from: https://www.nuget.org/account/apikeys
+  - Create a new API key with "Push" permission for the `DecentDB.MicroOrm` package
+  - Add the secret to repository settings: Settings → Secrets and variables → Actions → New repository secret
+  - If not configured, packages will still be published to GitHub Packages
+
+Both publish steps use `continue-on-error: true`, so if one target fails, the other will still be attempted.
 
 ## Creating a pre-release
 


### PR DESCRIPTION
This pull request updates the release workflow and documentation for DecentDB, focusing on improving NuGet package publishing and versioning. The most important changes are grouped below:

**NuGet Publishing Workflow Improvements:**

* The `.github/workflows/nuget.yml` workflow now publishes NuGet packages to both GitHub Packages and NuGet.org, with improved error handling and conditional publishing based on the presence of the `NUGET_API_KEY` secret.
* The workflow triggers have been simplified to match any tag starting with `v`, making releases easier and more consistent.
* Version handling in the workflow has been updated to support the new `1.0.2` release and its pre-release variants.

**Documentation and Metadata Updates:**

* The release documentation (`docs/development/releases.md`) has been updated to reflect the new publishing targets, trigger patterns, and required secrets, making it clearer how releases and NuGet publishing work.
* The NuGet package metadata (`DecentDB.MicroOrm.csproj`) now includes an updated description and adds the project URL for improved discoverability.

**Version Bumps:**

* The project version has been bumped to `1.0.2` in both the changelog and the `decentdb.nimble` file to reflect the new release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL8-R13) [[2]](diffhunk://#diff-13fd5bd11c7f1dd03bc2950025da456c8cf564ad1eac50b80797750dacf6c91eL1-R1)…g; bump version to 1.0.2