### PR TITLE
feat: update to version 1.1.3 and enhance static linking for .NET pac…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,9 +71,8 @@ jobs:
             cd /tmp/libpg_query
             make
           fi
-          cd /tmp/libpg_query
-          sudo make install
-          sudo ldconfig
+          mkdir -p build/lib
+          cp /tmp/libpg_query/libpg_query.a build/lib/
 
       - name: Build libpg_query (macOS)
         if: runner.os == 'macOS'
@@ -83,8 +82,8 @@ jobs:
             cd /tmp/libpg_query
             make
           fi
-          cd /tmp/libpg_query
-          sudo make install
+          mkdir -p build/lib
+          cp /tmp/libpg_query/libpg_query.a build/lib/
 
       - name: Build libpg_query (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -41,8 +41,8 @@ jobs:
           git clone --depth 1 https://github.com/pganalyze/libpg_query.git /tmp/libpg_query
           cd /tmp/libpg_query
           make
-          sudo make install
-          sudo ldconfig
+          mkdir -p "$GITHUB_WORKSPACE/build/lib"
+          cp libpg_query.a "$GITHUB_WORKSPACE/build/lib/"
 
       - name: Build libpg_query (macOS)
         if: runner.os == 'macOS'
@@ -50,7 +50,8 @@ jobs:
           git clone --depth 1 https://github.com/pganalyze/libpg_query.git /tmp/libpg_query
           cd /tmp/libpg_query
           make
-          sudo make install
+          mkdir -p "$GITHUB_WORKSPACE/build/lib"
+          cp libpg_query.a "$GITHUB_WORKSPACE/build/lib/"
 
       - name: Build libpg_query (Windows)
         if: runner.os == 'Windows'

--- a/decentdb.nimble
+++ b/decentdb.nimble
@@ -1,4 +1,4 @@
-version       = "1.1.2"
+version       = "1.1.3"
 author        = "DecentDB contributors"
 description   = "DecentDB engine"
 license       = "Apache-2.0"

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -5,6 +5,14 @@ All notable changes to DecentDB will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2026-02-18
+
+### Fixed
+- .NET: NuGet packages now statically link `libpg_query`, `xxhash`, and `protobuf-c` into `libdecentdb.so`. Previously these were dynamic dependencies not included in the package, causing `DllNotFoundException` on systems without them installed (e.g. `dotnet publish` to a clean server).
+
+### Changed
+- Build: Linux and macOS CI steps now use the `libpg_query.a` static archive instead of `sudo make install`, matching the Windows build and ensuring the shared library is self-contained.
+
 ## [1.1.2] - 2026-02-15
 
 ### Fixed

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,4 +1,3 @@
 --path:src
 --define:libpg_query
---passL:"-Lbuild/lib"
---passL:"-lpg_query"
+--passL:"build/lib/libpg_query.a"


### PR DESCRIPTION
This pull request updates the build and packaging process to ensure that the .NET NuGet package for DecentDB statically links its native dependencies, making deployments more reliable and self-contained. The changes address previous issues with missing shared libraries on target systems and align the build steps across all platforms.

Dependency linking and packaging improvements:

* The NuGet package now statically links `libpg_query`, `xxhash`, and `protobuf-c` into `libdecentdb.so`, resolving prior issues where these were dynamic dependencies and could cause `DllNotFoundException` on clean servers.
* The Nim build configuration (`nim.cfg`) is updated to link directly against the static `libpg_query.a` archive rather than relying on dynamic linking flags.

CI/build process changes:

* The Linux and macOS CI steps in `.github/workflows/nuget.yml` now copy the built `libpg_query.a` archive into the build directory instead of running `sudo make install`, ensuring the static library is available for linking and matching the Windows build process.

Versioning and documentation:

* The project version is bumped to `1.1.3` in `decentdb.nimble` to reflect these changes.
* The changelog (`docs/about/changelog.md`) is updated to document the fixes and build changes in version 1.1.3.…kages