### PR TITLE
Modify release workflow to copy libpg_query instead of install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
           git clone --depth 1 https://github.com/pganalyze/libpg_query.git /tmp/libpg_query
           cd /tmp/libpg_query
           make
-          sudo make install
-          sudo ldconfig
+          mkdir -p "$GITHUB_WORKSPACE/build/lib"
+          cp libpg_query.a "$GITHUB_WORKSPACE/build/lib/"
 
       - name: Build libpg_query (macOS)
         if: runner.os == 'macOS'
@@ -42,7 +42,8 @@ jobs:
           git clone --depth 1 https://github.com/pganalyze/libpg_query.git /tmp/libpg_query
           cd /tmp/libpg_query
           make
-          sudo make install
+          mkdir -p "$GITHUB_WORKSPACE/build/lib"
+          cp libpg_query.a "$GITHUB_WORKSPACE/build/lib/"
 
       - name: Build libpg_query (Windows)
         if: runner.os == 'Windows'


### PR DESCRIPTION
Updated the workflow to copy the built library to the workspace instead of installing it.